### PR TITLE
Feature/threshold remasking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+evaluations/outputs/
+build/
+python/dinfer.egg-info
+
+evaluations/tasks/mbpp_sanitized/__pycache__/*

--- a/evaluations/eval_llada_mini_remask.sh
+++ b/evaluations/eval_llada_mini_remask.sh
@@ -1,0 +1,41 @@
+# Set the environment variables first before running the command.
+export HF_ALLOW_CODE_EVAL=1
+export HF_DATASETS_TRUST_REMOTE_CODE=1
+export TRANSFORMERS_TRUST_REMOTE_CODE=1
+export CUDA_VISIBLE_DEVICES=4,5,6,7
+
+parallel_decoding='threshold' # or hierarchy
+length=2048 # generate length
+block_length=32 # block length
+model_path='/root/inclusion_data/separate_expert_model/LLaDA2.0-mini-preview' # your model path  
+threshold=0.98 # threshold for parallel decoding
+low_threshold=0.62 # low threshold for parallel decoding when using hierarchy mechanism
+cache='prefix' # or 'prefix' for prefix cache; or '' if you don't want to use cache
+warmup_times=0 # warmup times for cache
+prefix_look=0
+after_look=0
+cont_weight=0 # cont weight
+use_credit=False # enable credit for threshold mechanism
+use_compile=True # use compile
+tp_size=4 # tensor parallel size
+gpus='0;1;2;3' # gpus for tensor parallel inference
+parallel='tp' # 'tp' for tensor parallel or 'dp' for data parallel
+output_dir='./outputs' # your customer output path
+model_type='llada2' # llada2 (for llada2-mini) 
+use_bd=True # use block diffusion
+master_port="23458"
+save_samples=False # save samples
+enable_remask=True # enable remasking for threshold decoder
+# for llada 1.5 use tasks gsm8k_llada1.5 mbpp_sanitized_llada1.5
+# for llada2_mini use tasks gsm8k_llada_mini mbpp_sanitized_llada_mini
+if [ parallel=='tp' ]; then
+  for task in mbpp_sanitized_llada_mini; do
+    output_path=${output_dir}/${task}
+    python eval_dinfer_sglang.py --tasks ${task} \
+    --confirm_run_unsafe_code --model dInfer_eval \
+    --model_args model_path=${model_path},gen_length=${length},block_length=${block_length},threshold=${threshold},low_threshold=${low_threshold},show_speed=True,save_dir=${output_path},parallel_decoding=${parallel_decoding},cache=${cache},warmup_times=${warmup_times},use_compile=${use_compile},tp_size=${tp_size},parallel=${parallel},cont_weight=${cont_weight},use_credit=${use_credit},prefix_look=${prefix_look},after_look=${after_look},gpus=${gpus},model_type=${model_type},use_bd=${use_bd},master_port=${master_port},save_samples=${save_samples},enable_remask=${enable_remask} \
+    --output_path ${output_path} --include_path ./tasks --apply_chat_template
+  done
+else
+  echo "parallel must be tp"
+fi

--- a/python/dinfer/decoding/utils.py
+++ b/python/dinfer/decoding/utils.py
@@ -247,7 +247,9 @@ class BlockDiffusionIterator():
         current_block_end = min(current_block_start + self.block_length, self.x.total_length)
         assert current_block_end <= self.x.total_length
         self.iter += 1
-        return BlockLoc(current_block_start, current_block_end), self.x[current_block_start:current_block_end]
+        # Fix dimension bug: originally was self.x[current_block_start:current_block_end], 
+        # now correctly uses self.x[:, current_block_start:current_block_end] to handle batch dimension
+        return BlockLoc(current_block_start, current_block_end), self.x[:, current_block_start:current_block_end]
 
 
 class BlockIteratorFactory:


### PR DESCRIPTION
## Summary

This PR adds **Remasking-Based Decoding** support to dInfer’s parallel decoding framework and fixes a tensor slicing bug in the decoding utilities.

Remasking-based decoding is a commonly used strategy during decoding and has been introduced and adopted in several recent works:
- https://arxiv.org/pdf/2512.15596
- https://arxiv.org/pdf/2502.03540
- https://arxiv.org/pdf/2503.00307
- https://arxiv.org/pdf/2510.01384

In this PR, *remasking* specifically refers to **re-applying the mask to tokens that have already been unmasked in previous decoding steps, and re-decoding them in subsequent steps**. This allows the model to revise earlier predictions and improve global consistency during parallel decoding.

The current implementation in `python/dinfer/decoding/parallel_strategy.py` does not support this behavior. This PR extends the decoder to enable remasking while remaining fully backward compatible.

---

## What’s Changed

### 1. Remasking-Based Decoding Support
- Added remasking-based decoding to `ThresholdParallelDecoder` in  
  `python/dinfer/decoding/parallel_strategy.py`
- Introduced a new optional parameter: **`enable_remask`**
  - When enabled, previously unmasked tokens can be re-masked and re-decoded in later steps
  - Default behavior remains unchanged when `enable_remask` is not set
  - Existing workflows continue to work without modification
- Added an example evaluation script:
  - `evaluations/eval_llada_mini_remask.sh`
  - Demonstrates usage with remasking enabled
  - The only additional argument is `enable_remask`

### 2. Tensor Dimension Bug Fix
- Fixed an incorrect slicing operation in:
  - `python/dinfer/decoding/utils.py`
- The original implementation dropped the batch dimension when slicing `self.x`
- Updated the slicing logic to preserve the batch dimension, preventing downstream shape mismatches

---

## Usage

To enable remasking-based decoding, simply set:

```bash
enable_remask=true
```
---

## Experimental Results

Experiments were conducted using **inclusionAI/LLaDA2.0-mini-preview** with the following settings:

- **Block size**: 32  
- **Threshold**: 0.98  
- **Remasking**: enabled (`enable_remask = true`)

### Results

| Dataset | Temperature = 0.0 | Temperature = 0.8 |
|--------|------------------|------------------|
| MBPP   | 0.7611           | 0.7658           |
| GSM8K  | 0.8810           | 0.8749           |

